### PR TITLE
Automate air conditioner at night

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .envrc
+nature-remo-api/env.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # nature-remo-api
+
+[Nature Remo Cloud API](https://developer.nature.global/) を利用して、家電を自動化するスクリプト。
+
+開発やデプロイに関するコードは、`nature-remo-api` ディレクトリ以下で実行してください。
+
+## 関数
+
+- `nightBedRoomAirConditioner`: 夜間に自動でエアコンを動かす関数。暑かったら ON, 涼しくなったら OFF にする
+
+## Env
+
+```sh
+touch env.json
+```
+
+```env.json
+{
+  "nightBedRoomAirConditioner": {
+    "natureRemoAccessToken": "***",
+    "airconId": "***",
+    "deviceId": "***",
+    "hot": 30,
+    "cold": 25,
+    "airTemperature": 27
+  }
+}
+```
+
+## Dev
+
+ビルド後にローカルで Lambda 関数を実行。
+
+```sh
+npm start
+```
+
+## Deploy
+
+ビルド後に関数を AWS　Lambda へデプロイ。
+
+```sh
+npm run deploy
+```

--- a/nature-remo-api/README.md
+++ b/nature-remo-api/README.md
@@ -59,7 +59,7 @@ Test a single function by invoking it directly with a test event. An event is a 
 Run functions locally and invoke them with the `sam local invoke` command.
 
 ```bash
-my-application$ sam local invoke ScheduledEventLogger --event events/event-cloudwatch-event.json
+$ sam local invoke --env-vars env.json
 ```
 
 ## Add a resource to your application

--- a/nature-remo-api/README.md
+++ b/nature-remo-api/README.md
@@ -59,7 +59,7 @@ Test a single function by invoking it directly with a test event. An event is a 
 Run functions locally and invoke them with the `sam local invoke` command.
 
 ```bash
-$ sam local invoke --env-vars env.json
+$ sam local invoke nightBedRoomAirConditioner --env-vars env.json
 ```
 
 ## Add a resource to your application

--- a/nature-remo-api/package-lock.json
+++ b/nature-remo-api/package-lock.json
@@ -4,6 +4,11 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "node-fetch": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
         "prettier": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",

--- a/nature-remo-api/package.json
+++ b/nature-remo-api/package.json
@@ -11,6 +11,9 @@
     "prettier": "2.0.5"
   },
   "scripts": {
+    "build": "sam build",
+    "local": "sam local invoke nightBedRoomAirConditioner --env-vars env.json",
+    "start": "npm rum build && npm run local",
     "test": "jest"
   }
 }

--- a/nature-remo-api/package.json
+++ b/nature-remo-api/package.json
@@ -12,8 +12,11 @@
   },
   "scripts": {
     "build": "sam build",
-    "local": "sam local invoke nightBedRoomAirConditioner --env-vars env.json",
+    "env": "jq -r '.nightBedRoomAirConditioner | to_entries[] | \"ParameterKey=\\(.key),ParameterValue=\\(.value) \"' env.json",
+    "local": "sam local invoke nightBedRoomAirConditioner --parameter-overrides \"$(npm run env)\"",
     "start": "npm rum build && npm run local",
+    "deploy:sam": "sam deploy --parameter-overrides \"$(npm run env)\"",
+    "deploy": "npm run build && npm run deploy:sam",
     "test": "jest"
   }
 }

--- a/nature-remo-api/package.json
+++ b/nature-remo-api/package.json
@@ -3,7 +3,9 @@
   "description": "replaced-by-user-input",
   "version": "0.0.1",
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+    "node-fetch": "^2.6.0"
+  },
   "devDependencies": {
     "jest": "^24.7.1",
     "prettier": "2.0.5"

--- a/nature-remo-api/src/handlers/scheduled-event-logger.js
+++ b/nature-remo-api/src/handlers/scheduled-event-logger.js
@@ -1,8 +1,18 @@
 /**
  * A Lambda function that logs the payload received from a CloudWatch scheduled event.
  */
+
+const fetch = require('node-fetch');
+const accessToken = process.env.NATURE_REMO_ACCESS_TOKEN;
+
 exports.scheduledEventLoggerHandler = async (event, context) => {
   // All log statements are written to CloudWatch by default. For more information, see
   // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
-  console.info(JSON.stringify(event));
+  const res = await fetch('https://api.nature.global/1/devices', {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  });
+  console.dir(await res.json())
 };

--- a/nature-remo-api/src/handlers/scheduled-event-logger.js
+++ b/nature-remo-api/src/handlers/scheduled-event-logger.js
@@ -5,39 +5,43 @@
 const fetch = require("node-fetch");
 const accessToken = process.env.NATURE_REMO_ACCESS_TOKEN;
 const AIRCON_ID = process.env.AIRCON_ID;
+const DEVICE_ID = process.env.DEVICE_ID;
+const HOT = parseInt(process.env.HOT, 10);
+const COLD = parseInt(process.env.COLD, 10);
+const AIR_TEMPERATURE = process.env.AIR_TEMPERATURE;
 const BASE_URL = "https://api.nature.global/1";
 
 exports.nightBedRoomAirConditioner = async (event, context) => {
   // All log statements are written to CloudWatch by default. For more information, see
   // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
 
-  // const res = await turnOnAircon(AIRCON_ID, 28);
-  const res = await turnOffAircon(AIRCON_ID);
-  console.dir(res, { depth: 10 });
+  let res;
+
+  const devices = await getDevices();
+  const device = devices.filter((device) => device.id === DEVICE_ID)[0];
+  const temperature = device.newest_events.te.val;
+
+  switch (true) {
+    case (temperature >= HOT):
+      log(`[Temperature ${temperature}℃]: Turn on air conditoner`);
+      res = await turnOnAircon(AIRCON_ID, AIR_TEMPERATURE);
+      break;
+    case (temperature <= COLD):
+      log(`[Temperature ${temperature}℃]: Turn off air conditoner`);
+      res = await turnOffAircon(AIRCON_ID);
+      break;
+    default:
+      res = `[Temperature ${temperature}℃]: It's just the right room temperature`;
+      break;
+  }
+
+  log(res);
 };
+
+const log = (logObj) => (console.dir(logObj, { depth: 10 }) );
 
 const getDevices = async () => {
   const res = await fetch(`${BASE_URL}/devices`, {
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-  return await res.json();
-};
-
-const getAppliances = async () => {
-  const res = await fetch(`${BASE_URL}/appliances`, {
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-  return await res.json();
-};
-
-const getSignales = async (applianceId) => {
-  const res = await fetch(`${BASE_URL}/appliances/${applianceId}/signals`, {
     method: "GET",
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -76,6 +80,26 @@ const turnOffAircon = async (applianceId) => {
       Authorization: `Bearer ${accessToken}`,
     },
     body: params,
+  });
+  return await res.json();
+};
+
+const getAppliances = async () => {
+  const res = await fetch(`${BASE_URL}/appliances`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  return await res.json();
+};
+
+const getSignales = async (applianceId) => {
+  const res = await fetch(`${BASE_URL}/appliances/${applianceId}/signals`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
   return await res.json();
 };

--- a/nature-remo-api/src/handlers/scheduled-event-logger.js
+++ b/nature-remo-api/src/handlers/scheduled-event-logger.js
@@ -2,17 +2,80 @@
  * A Lambda function that logs the payload received from a CloudWatch scheduled event.
  */
 
-const fetch = require('node-fetch');
+const fetch = require("node-fetch");
 const accessToken = process.env.NATURE_REMO_ACCESS_TOKEN;
+const BASE_URL = 'https://api.nature.global/1'
+const PC_ROOM_AIRCON_ID = '***'
 
 exports.scheduledEventLoggerHandler = async (event, context) => {
   // All log statements are written to CloudWatch by default. For more information, see
   // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
-  const res = await fetch('https://api.nature.global/1/devices', {
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${accessToken}`
-    }
-  });
-  console.dir(await res.json())
+
+  const res = await trunOnAircon(PC_ROOM_AIRCON_ID)
+  // const res = await turnOffAircon(PC_ROOM_AIRCON_ID)
+  console.dir(res, { depth: 10 })
 };
+
+const getDevices = async () => {
+  const res = await fetch(`${BASE_URL}/devices`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  return await res.json()
+};
+
+const getAppliances = async () => {
+  const res = await fetch(`${BASE_URL}/appliances`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  return await res.json()
+}
+
+const getSignales = async (applianceId) => {
+  const res = await fetch(`${BASE_URL}/appliances/${applianceId}/signals`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  return await res.json()
+}
+
+const trunOnAircon = async (applianceId) => {
+  const endpoint = `${BASE_URL}/appliances/${applianceId}/aircon_settings`
+  const params = new URLSearchParams();
+  params.append('appliance', applianceId)
+  params.append('temperature', '26')
+  params.append('operation_mode', 'dry')
+  params.append('button', '')
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: params,
+  });
+  return await res.json()
+}
+
+const turnOffAircon = async (applianceId) => {
+  const endpoint = `${BASE_URL}/appliances/${applianceId}/aircon_settings`
+  const params = new URLSearchParams();
+  params.append('appliance', applianceId)
+  params.append('button', 'power-off')
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: params,
+  });
+  return await res.json()
+}

--- a/nature-remo-api/src/handlers/scheduled-event-logger.js
+++ b/nature-remo-api/src/handlers/scheduled-event-logger.js
@@ -4,16 +4,16 @@
 
 const fetch = require("node-fetch");
 const accessToken = process.env.NATURE_REMO_ACCESS_TOKEN;
-const BASE_URL = 'https://api.nature.global/1'
-const PC_ROOM_AIRCON_ID = '***'
+const AIRCON_ID = process.env.AIRCON_ID;
+const BASE_URL = "https://api.nature.global/1";
 
-exports.scheduledEventLoggerHandler = async (event, context) => {
+exports.nightBedRoomAirConditioner = async (event, context) => {
   // All log statements are written to CloudWatch by default. For more information, see
   // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-logging.html
 
-  const res = await trunOnAircon(PC_ROOM_AIRCON_ID)
-  // const res = await turnOffAircon(PC_ROOM_AIRCON_ID)
-  console.dir(res, { depth: 10 })
+  // const res = await turnOnAircon(AIRCON_ID, 28);
+  const res = await turnOffAircon(AIRCON_ID);
+  console.dir(res, { depth: 10 });
 };
 
 const getDevices = async () => {
@@ -23,7 +23,7 @@ const getDevices = async () => {
       Authorization: `Bearer ${accessToken}`,
     },
   });
-  return await res.json()
+  return await res.json();
 };
 
 const getAppliances = async () => {
@@ -33,8 +33,8 @@ const getAppliances = async () => {
       Authorization: `Bearer ${accessToken}`,
     },
   });
-  return await res.json()
-}
+  return await res.json();
+};
 
 const getSignales = async (applianceId) => {
   const res = await fetch(`${BASE_URL}/appliances/${applianceId}/signals`, {
@@ -43,16 +43,16 @@ const getSignales = async (applianceId) => {
       Authorization: `Bearer ${accessToken}`,
     },
   });
-  return await res.json()
-}
+  return await res.json();
+};
 
-const trunOnAircon = async (applianceId) => {
-  const endpoint = `${BASE_URL}/appliances/${applianceId}/aircon_settings`
+const turnOnAircon = async (applianceId, temperature) => {
+  const endpoint = `${BASE_URL}/appliances/${applianceId}/aircon_settings`;
   const params = new URLSearchParams();
-  params.append('appliance', applianceId)
-  params.append('temperature', '26')
-  params.append('operation_mode', 'dry')
-  params.append('button', '')
+  params.append("appliance", applianceId);
+  params.append("temperature", temperature);
+  params.append("operation_mode", "dry");
+  params.append("button", "");
 
   const res = await fetch(endpoint, {
     method: "POST",
@@ -61,14 +61,14 @@ const trunOnAircon = async (applianceId) => {
     },
     body: params,
   });
-  return await res.json()
-}
+  return await res.json();
+};
 
 const turnOffAircon = async (applianceId) => {
-  const endpoint = `${BASE_URL}/appliances/${applianceId}/aircon_settings`
+  const endpoint = `${BASE_URL}/appliances/${applianceId}/aircon_settings`;
   const params = new URLSearchParams();
-  params.append('appliance', applianceId)
-  params.append('button', 'power-off')
+  params.append("appliance", applianceId);
+  params.append("button", "power-off");
 
   const res = await fetch(endpoint, {
     method: "POST",
@@ -77,5 +77,5 @@ const turnOffAircon = async (applianceId) => {
     },
     body: params,
   });
-  return await res.json()
-}
+  return await res.json();
+};

--- a/nature-remo-api/template.yml
+++ b/nature-remo-api/template.yml
@@ -17,12 +17,12 @@ Transform:
 Resources:  
   # This is the Lambda function definition associated with the source code: sqs-payload-logger.js. For all available properties, see
   # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
-  ScheduledEventLogger:
+  nightBedRoomAirConditioner:
     Type: AWS::Serverless::Function
     Properties:
-      Description: A Lambda function that logs the payload of messages sent to an associated SQS queue.
+      Description: A Lambda function that manage bed room air conditioner
       Runtime: nodejs12.x
-      Handler: src/handlers/scheduled-event-logger.scheduledEventLoggerHandler
+      Handler: src/handlers/scheduled-event-logger.nightBedRoomAirConditioner
       # This property associates this Lambda function with a scheduled CloudWatch Event. For all available properties, see
       # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#schedule
       # This example runs every hour.
@@ -30,9 +30,10 @@ Resources:
         CloudWatchEvent:
           Type: Schedule
           Properties:
-            Schedule: cron(0 * * * ? *)
+            Schedule: cron(0/5 * * * ? *)
       MemorySize: 128
       Timeout: 100
       Environment:
         Variables:
           NATURE_REMO_ACCESS_TOKEN:
+          AIRCON_ID:

--- a/nature-remo-api/template.yml
+++ b/nature-remo-api/template.yml
@@ -33,3 +33,6 @@ Resources:
             Schedule: cron(0 * * * ? *)
       MemorySize: 128
       Timeout: 100
+      Environment:
+        Variables:
+          NATURE_REMO_ACCESS_TOKEN:

--- a/nature-remo-api/template.yml
+++ b/nature-remo-api/template.yml
@@ -37,3 +37,7 @@ Resources:
         Variables:
           NATURE_REMO_ACCESS_TOKEN:
           AIRCON_ID:
+          DEVICE_ID:
+          HOT:
+          COLD:
+          AIR_TEMPERATURE:

--- a/nature-remo-api/template.yml
+++ b/nature-remo-api/template.yml
@@ -44,7 +44,7 @@ Resources:
         CloudWatchEvent:
           Type: Schedule
           Properties:
-            Schedule: cron(0/5 * * * ? *)
+            Schedule: cron(0/5 0-8 * * ? *)
       MemorySize: 128
       Timeout: 100
       Environment:

--- a/nature-remo-api/template.yml
+++ b/nature-remo-api/template.yml
@@ -12,6 +12,20 @@ Description: >-
 Transform:
 - AWS::Serverless-2016-10-31
 
+Parameters:
+  natureRemoAccessToken:
+    Type: String
+  airconId:
+    Type: String
+  deviceId:
+    Type: String
+  hot:
+    Type: String
+  cold:
+    Type: String
+  airTemperature:
+    Type: String
+
 # Resources declares the AWS resources that you want to include in the stack
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
 Resources:  
@@ -35,9 +49,9 @@ Resources:
       Timeout: 100
       Environment:
         Variables:
-          NATURE_REMO_ACCESS_TOKEN:
-          AIRCON_ID:
-          DEVICE_ID:
-          HOT:
-          COLD:
-          AIR_TEMPERATURE:
+          NATURE_REMO_ACCESS_TOKEN: !Ref natureRemoAccessToken
+          AIRCON_ID: !Ref airconId
+          DEVICE_ID: !Ref deviceId
+          HOT: !Ref hot
+          COLD: !Ref cold
+          AIR_TEMPERATURE: !Ref airTemperature


### PR DESCRIPTION
## Environment Variables

認証情報や固定情報は環境変数で設定する。
SAM の Environment はデプロイ時に利用できないので、Parameters で上書きする形にしました。
以下のような内容で `env.json` を作成すると、それを jq で読み込んで環境変数に設定します。

```json
{
  "nightBedRoomAirConditioner": {
    "natureRemoAccessToken": "***",
    "airconId": "***",
    "deviceId": "***",
    "hot": 30,
    "cold": 25,
    "airTemperature": 27
  }
}
```

- [SAM deploy doesn't set environment variables · Issue #1163 · awslabs_aws-sam-cli](https://github.com/awslabs/aws-sam-cli/issues/1163#issuecomment-489864359)

## Cron
夜間のみ動作すれば良いので、毎日 0時 ~ 8時 に CloudWatch Events から Lamda を起動する

- [Schedule expressions using rate or cron - AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html)

## Price

無料利用枠を使うと無料で使える。
無料利用枠がなくても、0.03 USD。

```
単位変換
割り当てたメモリ量: 128 MB x 0.0009765625 GB in a MB = 0.125 GB
Pricing calculations
RoundUp (1000) = 1000 Duration rounded to nearest 100ms
14,400 requests x 1,000 ms x 0.001 ms to sec conversion factor = 14,400.00 total compute (seconds)
0.125 GB x 14,400.00 seconds = 1,800.00 total compute (GB-s)
1,800.00 GB-s x 0.0000166667 USD = 0.03 USD (monthly compute charges)
14,400 requests x 0.0000002 USD = 0.00 USD (monthly request charges)
0.03 USD + 0.00 USD = 0.03 USD
```
ref: [料金 - AWS Lambda ｜AWS](https://aws.amazon.com/jp/lambda/pricing/)