### PR TITLE
Cron 完了時刻から 10分前になったらエアコンを切る

### DIFF
--- a/src/utils/isCronDone.js
+++ b/src/utils/isCronDone.js
@@ -1,6 +1,7 @@
-const { isAfter, set } = require('date-fns');
+const { isAfter, set, sub } = require('date-fns');
 
 exports.isCronDone = () => {
-  const endTime = set(new Date(), { hours: 23 });
+  const cronEndTime = set(new Date(), { hours: 23 });
+  const endTime = sub(cronEndTime, { minutes: 10 });
   return isAfter(new Date(), endTime);
 };


### PR DESCRIPTION
Lambda の実行時間によって時間判定がずれることがあるので、10分の幅をとった。