### PR TITLE
Turn off air conditioner after cron end

### DIFF
--- a/src/utils/isCronDone.js
+++ b/src/utils/isCronDone.js
@@ -1,7 +1,6 @@
-const { isAfter, set, sub } = require('date-fns');
+const { isAfter, set } = require('date-fns');
 
 exports.isCronDone = () => {
-  const cronEndTime = set(new Date(), { hours: 23 });
-  const endTime = sub(cronEndTime, { minutes: 10 });
-  return isAfter(new Date(), endTime);
+  const cronEndTime = set(new Date(), { hours: 22, minutes: 55, seconds: 0 });
+  return isAfter(new Date(), cronEndTime);
 };

--- a/template.yml
+++ b/template.yml
@@ -30,6 +30,6 @@ Resources:
         CloudWatchEvent:
           Type: Schedule
           Properties:
-            Schedule: cron(0/5 14-23 * * ? *)
+            Schedule: cron(0/5 14-22 * * ? *)
       MemorySize: 128
       Timeout: 100


### PR DESCRIPTION
Fix cron time to turn off air conditioner after 8:00 am.
cf: [Schedule Expressions for Rules - Amazon CloudWatch Events](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions)